### PR TITLE
Two-arena binary choice example

### DIFF
--- a/2015_graz/binary_choice/two_arenas_real_real/_deploy_two_real_xinhib.sh
+++ b/2015_graz/binary_choice/two_arenas_real_real/_deploy_two_real_xinhib.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# a simple script to copy additional dependencies alongside the main CASU
+# controller during deployment.
+#
+# NOTE: makes explicit assumption for the experiment project name="sym_breaking_arena"
+# NOTE: this should be obselete since assisi-python issue #20 is closed.
+# initially preserving script since this workflow was used at workshop.
+# Notes from April 28 following worksop
+
+
+# declare deps & target CASUs
+deps=casu_utils.py loggers.py parsing.py two-real-with-cross.conf xinhib_heaters.py
+casus=001 003 004 006
+
+# first, run the built-in deployment (this creates relevant directories on remote side, as well as deploying the main config)
+cd deployment
+deploy.py oncasu_two_arena_xinhib_cross_between.assisi
+cd ..
+
+# now copy all extra dependencies
+for f in ${deps}; do
+    for casu in ${casus}; do
+        scp ${f} assisi@casu-${casu}:deploy/sym_breaking_arena/casu-${casu}
+    done
+done
+cd -
+
+

--- a/2015_graz/binary_choice/two_arenas_real_real/casu_utils.py
+++ b/2015_graz/binary_choice/two_arenas_real_real/casu_utils.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+'''
+a library of functions used in CASU controller dynamics. Got a lot of
+messy code that would be neater like this
+
+RM, Feb 2015
+
+'''
+
+import numpy as np
+from assisipy import casu
+#import matplotlib.cm as cm
+from datetime import datetime
+import parsing
+import time
+
+### ============= maths ============= ###
+
+#{{{ rolling_avg
+def rolling_avg(x, n):
+    '''
+    given the sample x, provide a rolling average taking n samples per data point.
+    NOT a quick solution, but easy...
+    '''
+    y = np.zeros((len(x),))
+    for ctr in range(len(x)):
+        y[ctr] = np.sum(x[ctr:(ctr+n)])
+
+    return y/n
+#}}}
+
+### ============= general behaviour ============= ###
+
+#{{{ measure_ir_sensors
+def measure_ir_sensors(mycasu, detect_data):
+    ''' count up sensors that detect a bee, plus rotate history array '''
+
+    # don't discriminate between specific directions, so just accumulate all
+    count = 0
+    for (val,t) in zip(mycasu.get_ir_raw_value(casu.ARRAY), mycasu.threshold):
+        if (val > t):
+            count += 1
+
+    #print "raw:", 
+    #print ",".join(["{:.2f}".format(x) for x in mycasu.get_ir_raw_value(casu.ARRAY)])
+    #mycasu.total_count += count # historical count over all time
+    detect_data = np.roll(detect_data, 1) # step all positions back
+    detect_data[0] = count      # and overwrite the first entry (this was rolled
+    # around, so is the oldest entry -- and to become the newest now)
+    # allow ext usage to apply window -- remain agnostic here during collection.
+    return detect_data, count
+
+#}}}
+#{{{ heater_one_step
+def heater_one_step(h):
+    '''legacy function'''
+    return detect_bee_proximity_saturated(h)
+
+def detect_bee_proximity_saturated(h):
+    # measure proximity
+    detect_data, count = measure_ir_sensors(h, h.detect_data)
+    h.detect_data = detect_data
+    # overall bee count for this casu
+    sat_count = min(h.sat_lim, count) # saturates
+    return sat_count
+#}}}
+
+#{{{ find_mean_ext_temp
+def find_mean_ext_temp(h):
+    r = []
+    for sensor in [casu.TEMP_F, casu.TEMP_B, casu.TEMP_L, casu.TEMP_R ]:
+        r.append(h.get_temp(sensor))
+
+    if len(r):
+        mean = sum(r) / float(len(r))
+    else:
+        mean = 0.0
+
+    return mean
+#}}}
+
+### ============= inter-casu comms ============= ###
+#{{{ comms functions
+def transmit_my_count(h, sat_count, dest='accomplice'):
+    s = "{}".format(sat_count)
+    if h.verb > 1:
+        print "\t[i]==> {} send msg ({} by): '{}' bees, to {}".format(
+            h._thename, len(s), s, dest)
+    h.send_message(dest, s)
+
+
+#TODO: this is non-specific, i.e., any message from anyone is assumed to have
+# the right form.  For heterogeneous neighbours, we need to check identity as
+# well
+
+def recv_all_msgs(h, retry_cnt=0, max_recv=None):
+    '''
+    continue to read message bffer until no more messages.
+    as list of parsed messages parsed into (src, float) pairs
+    '''
+    msgs = []
+    try_cnt = 0
+
+    while(True):
+        msg = h.read_message()
+        #print msg
+        if msg:
+            txt = msg['data'].strip()
+            src = msg['sender']
+            bee_cnt = float(txt.split()[0])
+            msgs.append((src, bee_cnt))
+
+            if h.verb >1:
+                print "\t[i]<== {3} recv msg ({2} by): '{1}' bees, {4} from {0} {5}".format(
+                    msg['sender'], bee_cnt, len(msg['data']), h._thename,
+                    BLU, ENDC)
+
+            if h.verb > 1:
+                #print dir(msg)
+                print msg.items()
+
+            if(max_recv is not None and len(msgs) >= max_recv):
+                break
+        else:
+            # buffer emptied, return
+            try_cnt += 1
+            if try_cnt > retry_cnt:
+                break
+
+    return msgs
+
+
+def recv_neighbour_msg(h):
+    bee_cnt = 0
+    msg = h.read_message()
+    #print msg
+    if msg:
+        txt = msg['data'].strip()
+        bee_cnt = int(txt.split()[0])
+        if h.verb >1:
+            print "\t[i]<== {3} recv msg ({2} by): '{1}' bees, from {0}".format(
+                msg['sender'], bee_cnt, len(msg['data']), h._thename)
+
+    return bee_cnt;
+
+def recv_neighbour_msg_w_src(h):
+    ''' provide the source of a message as well as the message count'''
+    bee_cnt = 0
+    src = None
+    msg = h.read_message()
+    #print msg
+    if msg:
+        txt = msg['data'].strip()
+        src = msg['sender']
+        bee_cnt = float(txt.split()[0])
+        if h.verb >1:
+            print "\t[i]<== {3} recv msg ({2} by): '{1}' bees, from {0}".format(
+                msg['sender'], bee_cnt, len(msg['data']), h._thename)
+        if h.verb > 1:
+            #print dir(msg)
+            print msg.items()
+
+    return bee_cnt, src
+
+
+def recv_neighbour_msg_flt(h):
+    bee_cnt = 0
+    msg = h.read_message()
+    #print msg
+    if msg:
+        txt = msg['data'].strip()
+        bee_cnt = float(txt.split()[0])
+        if h.verb > 1:
+            print "\t[i]<== {3} recv msg ({2} by): '{1}' bees, from {0}".format(
+                msg['sender'], bee_cnt, len(msg['data']), h._thename)
+
+    return bee_cnt;
+
+#}}}
+
+def find_comms_mapping(name, rtc_path, suffix='-sim', verb=True):
+    links = parsing.find_comm_link_mapping(
+            name, rtc_path=rtc_path, suffix=suffix, verb=verb)
+    if verb:
+        print "[I] for {}, found the following nodes/edges".format(name)
+        print "\t", links.items()
+        print "\n===================================\n\n"
+    return links
+
+
+
+### ============= display ============= ###
+
+#{{{ term codes for colored text
+ERR = '\033[41m'
+BLU = '\033[34m'
+ENDC = '\033[0m'
+#}}}
+#{{{ color funcs
+#def gen_cmap(m='hot', n=32) :
+#    return cm.get_cmap(m, n) # get LUT with 32 values -- some gradation but see steps
+
+def gen_clr_tgt(new_temp, cmap, tgt=None, min_temp=28.0, max_temp=38.0):
+    t_rng = float(max_temp - min_temp)
+    fr = (new_temp - min_temp) / t_rng
+    i = int(fr * len(cmap))
+    # compute basic color, if on target
+    #r,g,b,a = cmap(i)
+    g = 0.0; b = 0.0; a = 1.0;
+    
+    i = sorted([0, i, len(cmap)-1])[1]
+    r = cmap[i]
+
+    # now adjust according to distance from target
+    if tgt is None: tgt=new_temp
+
+    dt = np.abs(new_temp - tgt)
+    dt_r = dt / t_rng
+    h2 = np.array([r,g,b])
+    h2 *= (1-dt_r)
+
+    return h2
+
+# a colormap with 8 settings, taht doesn't depend on the presence of
+# matplotlib (hard-coded though.) -- depricating
+_clrs = [
+        (0.2, 0.2, 0.2),
+        (0.041, 0, 0),
+        (0.412, 0, 0),
+        (0.793, 0, 0),
+        (1, 0.174, 0),
+        (1, 0.555, 0),
+        (1, 0.936, 0),
+        (1, 1, 0.475),
+        (1, 1, 1),
+        ]
+
+_dflt_clr = (0.2, 0.2, 0.2)
+
+# can access other gradations of colour using M = cm.hot(n) for n steps, then
+# either extract them once (`clrs = M(arange(n)`) or each time ( `clr_x = M(x)`)
+# BT here we're going to use 8 steps for all CASUs so no bother.
+
+#}}}
+
+def sep_with_nowtime():
+    print "# =================== t={} =================== #\n".format(
+        datetime.now().strftime("%H:%M:%S"))
+
+### ============= more generic ============= ###
+#{{{ a struct constructor
+# some handy python utilities, from Kier Dugan
+class Struct:
+  def __init__ (self, **kwargs):
+    self.__dict__.update (kwargs)
+
+  def get(self, key, default=None):
+      return self.__dict__.get(key, default)
+
+
+  def addFields(self, **kwargs):
+    # add other fields (basically variables) after initialisation
+    self.__dict__.update (kwargs)
+
+#}}}
+
+
+
+### calibraiont
+def _calibrate(h, calib_steps, calib_gain=1.1, interval=0.1):
+    '''
+    read the sensors several times, and take the highest reading
+    seen as the threshold.
+    '''
+    h._raw_thresh = [0] * 7 # default cases for threshold
+    for stp in xrange(calib_steps):
+        for i, v in enumerate(h.get_ir_raw_value(casu.ARRAY)):
+            if v > h._raw_thresh[i]:
+                h._raw_thresh[i] = v
+        time.sleep(interval)
+
+    h.thresh = [x*calib_gain for x in h._raw_thresh]
+    h.threshold = [x*calib_gain for x in h._raw_thresh]
+
+    if h.verb:
+        _ts =", ".join(["{:.2f}".format(x) for x in h.thresh])
+        print "[I] post-calibration, we have thresh: ", _ts
+
+    
+
+
+
+
+
+

--- a/2015_graz/binary_choice/two_arenas_real_real/deployment/oncasu_two_arena_xinhib_cross_between.assisi
+++ b/2015_graz/binary_choice/two_arenas_real_real/deployment/oncasu_two_arena_xinhib_cross_between.assisi
@@ -1,0 +1,8 @@
+# This file describes a deployment project
+
+# Arena description file -- this holds for both comms patterns
+arena : two_arena_in3x3.arena
+# Neighborhood graph -- this must be specific to the comms pattern
+nbg : two_arena_cross_in3x3.nbg
+# Deployment specification -- selects which controller to which CASU. Initially ok to leave same.
+dep : twoarena_casu_xinhib.dep

--- a/2015_graz/binary_choice/two_arenas_real_real/deployment/two_arena_cross_in3x3.nbg
+++ b/2015_graz/binary_choice/two_arenas_real_real/deployment/two_arena_cross_in3x3.nbg
@@ -1,0 +1,14 @@
+digraph one_arena_in3x3 {
+    subgraph "sym_breaking_arena" {
+        "casu-001" -> "casu-004" [ label = "enemy" ]
+        "casu-004" -> "casu-001" [ label = "enemy" ]
+        "casu-003" -> "casu-006" [ label = "enemy" ]
+        "casu-006" -> "casu-003" [ label = "enemy" ]
+
+        "casu-001" -> "casu-006" [ label = "accomplice" ]
+        "casu-006" -> "casu-001" [ label = "accomplice" ]
+
+        "casu-003" -> "casu-004" [ label = "accomplice" ]
+        "casu-004" -> "casu-003" [ label = "accomplice" ]
+    }
+}

--- a/2015_graz/binary_choice/two_arenas_real_real/deployment/two_arena_horizontal_in3x3.nbg
+++ b/2015_graz/binary_choice/two_arenas_real_real/deployment/two_arena_horizontal_in3x3.nbg
@@ -1,0 +1,14 @@
+digraph one_arena_in3x3 {
+    subgraph "sym_breaking_arena" {
+        "casu-001" -> "casu-004" [ label = "enemy" ]
+        "casu-004" -> "casu-001" [ label = "enemy" ]
+        "casu-003" -> "casu-006" [ label = "enemy" ]
+        "casu-006" -> "casu-003" [ label = "enemy" ]
+
+        "casu-001" -> "casu-003" [ label = "accomplice" ]
+        "casu-003" -> "casu-001" [ label = "accomplice" ]
+
+        "casu-004" -> "casu-006" [ label = "accomplice" ]
+        "casu-006" -> "casu-004" [ label = "accomplice" ]
+    }
+}

--- a/2015_graz/binary_choice/two_arenas_real_real/deployment/two_arena_in3x3.arena
+++ b/2015_graz/binary_choice/two_arenas_real_real/deployment/two_arena_in3x3.arena
@@ -1,0 +1,34 @@
+# A simple configuration file describing a 3x3 arena
+
+# Layer names can be assigned arbitrarily, 
+# as long as they consist only of letters, dashes and underscores
+
+# A sim- prefix in layer names defines layers of objects 
+# that will be spawned in the simulator when running sim.py 
+# on this file
+
+sym_breaking_arena :
+    # Casu names have to start with casu- in order for
+    # automatic spawning to work; they are also only
+    # allowed to contain letters, dashes and underscores
+    casu-001 :
+        pose : {x : -5, y : 5, yaw : 0}
+        sub_addr : tcp://casu-001:1555
+        pub_addr : tcp://casu-001:1556
+        msg_addr : tcp://casu-001:10201
+    casu-003 :
+        pose : {x : 5, y : 5, yaw : 0}
+        sub_addr : tcp://casu-003:1555
+        pub_addr : tcp://casu-003:1556
+        msg_addr : tcp://casu-003:10203
+    casu-004 :
+        pose : {x : -5, y : 0, yaw : 0}
+        sub_addr : tcp://casu-004:2555
+        pub_addr : tcp://casu-004:2556
+        msg_addr : tcp://casu-004:20204
+    casu-006 :
+        pose : {x : 5, y : 0, yaw : 0}
+        sub_addr : tcp://casu-006:2555
+        pub_addr : tcp://casu-006:2556
+        msg_addr : tcp://casu-006:20206
+

--- a/2015_graz/binary_choice/two_arenas_real_real/deployment/twoarena_casu_xinhib.dep
+++ b/2015_graz/binary_choice/two_arenas_real_real/deployment/twoarena_casu_xinhib.dep
@@ -1,0 +1,27 @@
+# Deployment specification file
+# For each casu in the arena, we need to specifiy:
+#     - the hostname of the target machine
+#     - the controller and additional files to deploy
+
+sym_breaking_arena :
+    casu-001 : 
+        hostname : casu-001
+        user : assisi
+        prefix : deploy 
+        controller: ../xinhib_heaters.py
+    casu-004 : 
+        hostname : casu-004
+        user : assisi
+        prefix : deploy
+        controller: ../xinhib_heaters.py
+
+    casu-003 : 
+        hostname : casu-003
+        user : assisi
+        prefix : deploy 
+        controller: ../xinhib_heaters.py
+    casu-006 : 
+        hostname : casu-006
+        user : assisi
+        prefix : deploy 
+        controller: ../xinhib_heaters.py

--- a/2015_graz/binary_choice/two_arenas_real_real/loggers.py
+++ b/2015_graz/binary_choice/two_arenas_real_real/loggers.py
@@ -1,0 +1,233 @@
+'''
+classes and utilities to aid with logging bee behaviour from enki
+'''
+import os
+import time
+import random
+from math import pi
+
+#{{{ logging bees
+class LogBeeActivity(object):
+    def __init__(self, bee_to_log, logfile, append=True, delimiter=';'):
+        '''
+        class to write logs for the bee activity through a simulation.
+        The records will be made in a non-evenly spaced way since there
+        are many different delays through the control loop
+        '''
+        self.bee = bee_to_log
+        mode = 'a' if append else 'w'
+        self.LINE_END = os.linesep # platform-independent line endings
+        self._delimeter = delimiter
+        try:
+            self.logfile = open(logfile, mode)
+        except IOError as e:
+            print "[F] cannot open logfile ({})".format(e)
+            raise
+
+
+    def record_pos(self, suffix=''):
+        '''
+        consistently write output for a given recording step
+        timestamp, pos(x), pos(y), yaw, temperature,
+        '''
+        fields = []
+        t = time.time()
+        #print "Finished at:",  datetime.datetime.fromtimestamp(time.time())
+        fields.append(t)
+        fields.extend(self.bee.get_true_pose()) # three floats returned
+        fields.append(self.bee.get_temp())
+        # because times have many SF, we print the data for all fields in full
+        #print len(fields), fields
+        s = self._delimeter.join([str(f) for f in fields])
+        if len(suffix):
+            s += self._delimeter + suffix
+            #s += ";" + suffix
+        s += self.LINE_END
+        self.logfile.write(s)
+
+    def _cleanup(self):
+        self.logfile.close()
+        print "closed logfile"
+
+class FakeBee(object):
+    ''' a fake bee that generates random results with same interface as
+    the assisipy bees'''
+    def __init__(self, name):
+        self.name = name
+    def get_true_pose(self):
+        x   = random.uniform(-10, 10)
+        y   = random.uniform(-10, 10)
+        yaw = random.uniform(-pi, pi)
+        return (x, y, yaw)
+
+    def get_temp(self):
+        t = random.uniform(20,45)
+        return t
+
+
+def test_bee_logger():
+    ''' show basic use case of the bee logger'''
+    mybee = FakeBee('goat1')
+    logger = LogBeeActivity(mybee, "/tmp/log.csv", False, delimiter=',')
+
+    for _ in xrange(23):
+        logger.record_pos()
+        time.sleep(random.uniform(0.3, 2))
+
+    logger._cleanup() # want this to happen by just deleting the obejct..
+
+
+
+
+#}}}
+
+#{{{ logging CASUs
+#{{{ LogCASUActivity
+class LogCASUActivity(object):
+    def __init__(self, casu_to_log, logfile, append=True, delimiter=';'):
+        '''
+        class to write logs for the CASU activity through a simulation.
+        The records will be made in a non-evenly spaced way since there
+        are many different delays through the control loop -- indeed, it
+        is totally possible to have event-driven behaviour
+
+        What does this log?
+        v1.0: timestamp, temp of sensors [N,E,S,W,int], IR sensors [0..5]
+        '''
+        self.version = 1.0
+        self.casu = casu_to_log
+        mode = 'a' if append else 'w'
+        self.LINE_END = os.linesep # platform-independent line endings
+        self._delimeter = delimiter
+        self._logfile_name = logfile
+        try:
+            self.logfile = open(logfile, mode)
+        except IOError as e:
+            print "[F] cannot open logfile ({})".format(e)
+            raise
+
+    def get_all_casu_temps(self):
+        ''' convenience method to get all temps.'''
+        # should this actually be in the logger rather than the
+        # fake casu? downside this now depends on importing
+        # assispy.casu
+        TEMP_SENSOR_ID_LIST = [8, 9, 10, 11, 12]
+        t = [self.casu.get_temp(sensor) for
+             sensor in TEMP_SENSOR_ID_LIST]
+        return t
+
+    def record_sensors(self, suffix=''):
+        '''
+        consistently write output for a given recording step
+        timestamp, sensor temps [NESW I], sensor readings[1..6]
+        '''
+        IR_ARRAY = 10000
+        fields = []
+        t = time.time()
+        #print "Finished at:",  datetime.datetime.fromtimestamp(time.time())
+        fields.append(t)
+        fields.extend(self.get_all_casu_temps()) # 5 floats
+        #fields.extend(self.casu.get_ir_raw_value(self.casu.IR_ARRAY)) # 6 floats
+        fields.extend(self.casu.get_ir_raw_value(IR_ARRAY)) # 6 floats
+        # because times have many SF, we print the data for all fields in full
+        #print len(fields), fields
+        s = self._delimeter.join([str(f) for f in fields])
+        if len(suffix):
+            s += self._delimeter + suffix
+            #s += ";" + suffix
+        s += self.LINE_END
+        self.logfile.write(s)
+
+    def _cleanup(self):
+        self.logfile.close()
+        print "[I] LogCASUActivity - closed logfile '{}'".format(
+            self._logfile_name)
+#}}}
+
+#{{{ fake casu
+class FakeCASU(object):
+    ''' a fake casu that generates random results with same interface as
+    the assisipy casus'''
+    def __init__(self, name):
+        self.name = name
+
+        self.IR_SENSORS = {
+            'IR_N' :0,
+            'IR_NE':1,
+            'IR_SW':2,
+            'IR_S' :3,
+            'IR_SE':4,
+            'IR_NW':5,
+        }
+        # should these be ordered dicts?
+        self.temp_sensors = {
+            'TEMP_N'  :0,
+            'TEMP_E'  :1,
+            'TEMP_S'  :2,
+            'TEMP_W'  :3,
+            'TEMP_TOP':4,
+        }
+
+        self.IR_SENSOR_MAP = {v: k for k, v in self.IR_SENSORS.iteritems()}
+        self.IR_IGNORED = 0 #<F4
+        self.IR_ARRAY = 10000 # same value as from assisipy.casu
+        self.TEMP_ARRAY = 10000
+
+    def _get_all_ir_values(self):
+        ''' return an array for all of the IR values '''
+        # turns out just passing in casu.ARRAY gets you all IR readings
+        raw_irs = [self.get_ir_raw_value(sensor) for
+                   sensor in self.IR_SENSORS.values()]
+        return raw_irs
+
+    def get_ir_raw_value(self, sensor=0):
+        ''' make up an IR value '''
+        if sensor == self.IR_ARRAY:
+            vals = [ random.uniform(0,100) for _ in xrange(len(self.IR_SENSORS))]
+        else:
+            vals = random.uniform(0,100)
+
+        return vals
+
+    def _get_all_temps(self):
+        ''' convenience method to get all temps.'''
+        # should this actually be in the logger rather than the
+        # fake casu?
+        t = [self.get_temp(sensor) for
+             sensor in self.temp_sensors.values()]
+        return t
+
+    def get_temp(self, sensor=0):
+        ''' make up a temp for the given temp sensor '''
+        # note: I've invented an array return func, which is probably
+        # bad practice since it doesn't yet exist in the API
+        if sensor == self.TEMP_ARRAY:
+            t = [random.uniform(20,45) for _ in xrange(len(self.temp_sensors))]
+        else:
+            t = random.uniform(20,45)
+        return t
+#}}}
+
+def test_casu_logger():
+    ''' show basic use case of the casu logger'''
+    mycasu = FakeCASU('saucer')
+    logger = LogCASUActivity(mycasu, "/tmp/casu_log.csv", False, delimiter=',')
+
+    for _ in xrange(23):
+        logger.record_sensors()
+        time.sleep(random.uniform(0.3, 2))
+
+    logger._cleanup() # want this to happen by just deleting the obejct..
+
+
+
+#}}}
+
+
+
+if __name__ == '__main__':
+    test_bee_logger()
+
+    test_casu_logger()
+
+

--- a/2015_graz/binary_choice/two_arenas_real_real/parsing.py
+++ b/2015_graz/binary_choice/two_arenas_real_real/parsing.py
@@ -1,0 +1,74 @@
+import yaml
+import os
+
+
+#{{{ find_comm_links -- maybe should be in utils or parsing lib?
+def find_comm_links(casu_names, rtc_path, suffix="-sim", verb=False):
+    nodes = []
+    edges = []
+
+    # for each rtc file, find the nodes specified, and any communication links
+    for name in casu_names:
+        fname = "{}{}.rtc".format(name, suffix)
+        rtc = os.path.join(rtc_path, fname)
+        if verb: print "[I] considering casu {} \n\t('{}')".format(name, rtc)
+        # should handle the possibility of file missing!
+        try:
+            deploy = yaml.safe_load(file(rtc, 'r'))
+            # verify that the deployment file is for the same named object
+            if not name == deploy['name']:
+                print "[W] CASU RTC file mismatching this casu, skipping", name, deploy['name']
+                continue
+            nodes.append(name)
+            if 'neighbors' in deploy and deploy['neighbors'] is not None:
+                for k, v in deploy['neighbors'].iteritems():
+                    n = v.get('name', None)
+                    if verb > 1: print v, n
+                    if n:
+                        edges.append((name, n))
+        except IOError:
+            print "[W] could not read rtc conf file for casu {}".format(name)
+
+
+    return nodes, edges
+#}}}
+#{{{ find_comm_link_mapping
+def find_comm_link_mapping(casu_name, rtc_path, suffix="-sim", verb=False):
+    '''
+    find all links in rtc file, and return in a mapping from physical target
+    to logical name (when receiving messages, the physical name is provided but
+    the CASU behaviour is typically defined in terms of logical names).
+
+    :param str casu_name: name of the CASU to inspect
+    :param str rtc_path:  the directory containing rtc files
+    :param str suffix:    suffix for RTC convention (e.g. -sim or -physical)
+    :param bool verb:     verbose output switch
+    :return:              dict of physical:logical names
+
+    '''
+
+    phys_logi_map = {}
+
+    fname = "{}{}.rtc".format(casu_name, suffix)
+    rtc = os.path.join(rtc_path, fname)
+    if verb: print "[I] considering casu {} \n\t('{}')".format(casu_name, rtc)
+    # should handle the possibility of file missing!
+    try:
+        deploy = yaml.safe_load(file(rtc, 'r'))
+        # verify that the deployment file is for the same named object
+        if not casu_name == deploy['name']:
+            print "[W] CASU RTC file mismatching this casu, skipping", casu_name, deploy['name']
+
+        elif 'neighbors' in deploy and deploy['neighbors'] is not None:
+            for k, v in deploy['neighbors'].iteritems():
+                neigh = v.get('name', None)
+                if verb > 1: print v, neigh
+                if neigh:
+                    phys_logi_map[neigh] = k
+
+    except IOError:
+        print "[W] could not read rtc conf file for casu {}".format(casu_name)
+
+
+    return phys_logi_map
+#}}}

--- a/2015_graz/binary_choice/two_arenas_real_real/two-real-with-cross.conf
+++ b/2015_graz/binary_choice/two_arenas_real_real/two-real-with-cross.conf
@@ -1,0 +1,78 @@
+# configuration file for the CASU controllers that use 
+# cross-inhib within arena, and cross-pattern of interaction between arenas
+
+# Note: this config includes an explicit defininition of the toplogy,
+#   which I *think* is not used. However, since the code definitely works,
+#   and we were pushed for time in the workshop, these fields remain.
+#   (specifically, the entries in 'friend' and 'enemy')
+
+# RM, notes written 28 April, following Graz workshop April 2015.
+
+
+shared : 
+    min_temp  : 28.
+    max_temp  : 36.5
+    sat_lim   : 4
+    max_steps : 8 # 2*sat_lim # 8 # steps saturate at 4 per casu.
+
+
+    # timing of update
+    resample_period : 0.25
+    update_period : 20.
+    rel_upd_rate : int(update_period / resample_period)
+    hist_len : 80
+    avg_hist_len : 80
+
+    # interactions -- which ones?
+    cross_inhib     : True
+    remote_excit    : True
+
+
+
+
+'casu_conf' : {
+    'casu-001':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-006',
+        'enemy'  : 'casu-004',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+    'casu-004':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-003',
+        'enemy'  : 'casu-001',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+
+    'casu-003':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-004',
+        'enemy'  : 'casu-006',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+    'casu-006':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-001',
+        'enemy'  : 'casu-003',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+}
+
+
+

--- a/2015_graz/binary_choice/two_arenas_real_real/two-real-with-horiz.conf
+++ b/2015_graz/binary_choice/two_arenas_real_real/two-real-with-horiz.conf
@@ -1,0 +1,67 @@
+shared : 
+    min_temp  : 28.
+    max_temp  : 38.
+    sat_lim   : 4
+    max_steps : 8 # 2*sat_lim # 8 # steps saturate at 4 per casu.
+
+
+    # timing of update
+    resample_period : 0.25
+    update_period : 20.
+    rel_upd_rate : int(update_period / resample_period)
+    hist_len : 80
+    avg_hist_len : 80
+
+    # interactions -- which ones?
+    cross_inhib     : True
+    remote_excit    : True
+
+
+
+
+'casu_conf' : {
+    'casu-001':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-003',
+        'enemy'  : 'casu-004',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+    'casu-004':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-006',
+        'enemy'  : 'casu-001',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+
+    'casu-003':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-001',
+        'enemy'  : 'casu-006',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+    'casu-006':  { # LRC
+        'bias'   : 0.0,
+        'sendto' : ['enemy', 'accomplice'],
+        'listen' : 'yes',
+        'friend' : 'casu-004',
+        'enemy'  : 'casu-003',
+        'self_bias'  : 0.5,
+        'friend_bias': 0.5,
+        'enemy_bias' : 1.0,
+    },
+}
+
+
+

--- a/2015_graz/binary_choice/two_arenas_real_real/two_arenas_real_real.rst
+++ b/2015_graz/binary_choice/two_arenas_real_real/two_arenas_real_real.rst
@@ -1,3 +1,73 @@
 Two arenas (real-real)
 ======================
 
+An experiment comprising two arenas, each of 2 CASUs and a group of bees.  The
+CASUs in each arena compete to attract the bees, through a positive feedback 
+coupling between the presence of bees and temperature emitted by the CASUs. 
+Additionally, there is a negative feedback coupling between CASUs in the same
+arena, i.e., lateral cross-inhibition (between 'enemy' CASUs).
+
+Finally, to test whether we can coordinate activity/collective decisions made
+in both arenas, we also introduce coupling between specific pairs of CASUs: in
+each arena, each CASU has a collaborator ('friend') in the other arena.  They
+share their local bee detection estimates, which can be thought of as giving
+each CASU 12 IR sensors instead of 6.
+
+
+To run this experiment, we use the deployment tools from assisi-python.
+However, one extra helper script is used in deployment:
+
+
+
+Protocol used to run experiments
+--------------------------------
+
+1. cd <workshops_repo_home>/2015_graz/binary_choice/two_arenas_real_real
+
+2. deploy the programs
+./_deploy_two_real_xinhib.sh
+
+3. start the CASU controllers, *with lab door shut* or under whatever lighting
+   conditions the experiment will run in
+
+cd deployment
+assisirun.py oncasu_two_arena_xinhib_cross_between.assisi
+
+4. wait for all CASUs to finish IR sensor calibration (approx 10 sec; displayed
+   in terminal)
+
+5. start video recordings as appropriate
+
+6. put bees into both arenas
+   restore lab conditions as for #3
+
+
+
+Alternative topology
+--------------------
+
+The central topology provided here uses CASUs [1,3] and [4,6] in two arenas,
+and couples them in a "cross" pattern.  This means that if there is any thermal
+coupling from one arena to the other, a successful coordination has to work
+against it.
+
+To change the topology to a "horizontal links" pattern (where both arenas will
+choose top or both choose bottom, if successfully coordinated), the following
+files should be modified:
+
+./
+  oncasu_two_arena_xinhib_cross_between.assisi
+  s/two-real-with-cross.conf/two-real-with-horiz.conf/
+   
+deployment/
+  oncasu_two_arena_xinhib_cross_between.assisi
+  s/two_arena_cross_in3x3.nbg/two_arena_horizontal_in3x3.nbg/
+
+  
+
+
+
+
+
+
+

--- a/2015_graz/binary_choice/two_arenas_real_real/xinhib_heaters.py
+++ b/2015_graz/binary_choice/two_arenas_real_real/xinhib_heaters.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+'''
+Four CASUs, with +ve feedback from self and from remote collaborator
+ (assumed to be in another arena); and -ve cross-inhibition from
+ local-ish competitor (assumed to be in local arena)
+
+However, we have (optional/configurable) asymmetry in the interactions,
+and different robots have to be set up to listen than to emit.
+
+Approx. a winner-takes all neural circuit in each arena
+'''
+
+# imports
+from assisipy import casu
+import loggers as loglib
+import numpy as np
+import argparse, os, time
+import sys
+import casu_utils as clib
+import yaml
+from time import gmtime, strftime
+import time
+
+ENABLE_SET_TEMP = True
+ENABLE_SET_LEDS = False
+
+def update_temp_wrapper(h, new_temp, ref_deviate):
+    '''
+    only change the temperture when we requested somehting far enough
+    away that it will make a difference.  This is only to work around
+    the frequency of setting new values.
+
+    '''
+    
+    if abs(new_temp - h.old_temp) > ref_deviate:
+        # make a new request
+        h.set_temp(new_temp)
+        # update the info on it
+        now = time.time()
+        elap = now - h.last_rq_time
+        h.last_rq_time = now
+        tstr = strftime("%H:%M:%S-%Z", gmtime())
+        print "[I] requested new temp @{} from {:.2f} to {:.2f}".format(
+                tstr, h.old_temp, new_temp)
+        h.old_temp = new_temp
+
+
+
+class Fakeobj(object):
+    ''' just have an object we can add properties to'''
+    def __init__(self):
+        self._thing = "yo"
+
+if __name__ == "__main__":
+    #{{{ external parameters
+    #parser = argparse.ArgumentParser()
+    #parser.add_argument('-p', '--rtc-path', type=str, default='',
+    #                    help="location of RTC files to configure CASUs",)
+    #parser.add_argument('--logpath', type=str, required=True,
+    #                    help="path to record output in")
+    #parser.add_argument('--casu-set', type=str, required=True, choices=['north', 'south'],
+    #                    help="Which set of casus")
+    #parser.add_argument('-c', '--conf-file', type=str, default=None)
+    ##TODO: incorporate the casu-set into conf file?
+    #parser.add_argument('-v', '--verb', type=int, default=0,
+    #                    help="verbosity level")
+    #parser = argparse.ArgumentParser()
+    #args = parser.parse_args()
+    args = Fakeobj()
+    args.rtc_path = ''
+    args.logpath = './'
+    args.verb = 1
+    args.conf_file = "two-real-with-cross.conf"
+    INPUT_CASU_NAME = 'casu-broken!'
+    if len(sys.argv) > 1:
+        INPUT_CASU_NAME = sys.argv[1]
+        if INPUT_CASU_NAME.endswith('.rtc'):
+            INPUT_CASU_NAME = INPUT_CASU_NAME[:-4]
+    #}}}
+
+    #{{{ set up parameters / other config
+    if args.conf_file is not None:
+        with open(args.conf_file, 'r') as f:
+            all_conf = yaml.safe_load(f)
+            _casu_conf = all_conf.get('casu_conf')
+            _shared_conf = all_conf.get('shared')
+    else:
+        _casu_conf = {}
+        _shared_conf = {}
+        # fatal error?
+
+    ### any derived parameters
+    casu_conf = _casu_conf # this one stay as dict for now
+    shared_conf = clib.Struct(**_shared_conf) # turn into dotted access.
+
+
+    # temp setup
+    shared_conf.temp_rng = shared_conf.max_temp - shared_conf.min_temp
+    shared_conf.temp_resolution = shared_conf.temp_rng / shared_conf.max_steps
+
+    # timing of update
+    shared_conf.rel_upd_rate = int (shared_conf.update_period /
+            shared_conf.resample_period)
+
+    print "## funamental config:"
+    for k in 'cross_inhib', 'remote_excit':
+        print "\t{} : {}".format(k, shared_conf.get(k))
+    # display.
+
+    #cmap = clib.gen_cmap()
+    cmap_fake = np.linspace(0, 1, num=8)
+    #}}}
+
+    #{{{ set up the casu objects / handles
+    heaters = []
+    loggers = []
+    init_upd_time = time.time()
+    _logtime= strftime("%H:%M:%S-%Z", gmtime())
+    for name in [INPUT_CASU_NAME, ] :
+
+        fname = "{}.rtc".format(name)
+        rtc   = os.path.join(args.rtc_path, fname)
+        print "connecting to casu {} ('{}')".format(name, rtc)
+        # connect to the casu and set up extra properties
+        h = casu.Casu(rtc_file_name=rtc, log=True)
+        # identify the logical/physical mapping to neighbours. # ONLY REQD UNTIL # PR#12 merged
+        h.comm_links = clib.find_comms_mapping(
+            name, rtc_path=args.rtc_path, suffix='', verb=True)
+        # basic params, from setup file
+        h._thename    = name
+        h._listento   = casu_conf[name]['listen']
+        h._sendto     = casu_conf[name]['sendto']
+        h.self_bias   = casu_conf[name]['self_bias']
+        h.friend_bias = casu_conf[name]['friend_bias']
+        h.enemy_bias  = casu_conf[name]['enemy_bias']
+        h.verb        = args.verb
+        h.max_steps   = float(shared_conf.max_steps)
+        h.sat_lim     = shared_conf.sat_lim
+        h.threshold   = 7*[0]
+
+        # memory/states, counters
+        h.detect_data = np.zeros(shared_conf.hist_len,)
+        h.last_update_time = init_upd_time
+        h.prev_temp   = shared_conf.min_temp
+        h.enemy_most_recent_val  = 0
+        h.friend_most_recent_val = 0
+        h.enemy_rx   = 0 # debug: count balance of msgs recv from each neighbor
+        h.friend_rx  = 0 # ditto
+        h.err_cnt    = 0 # this just keeps track of windowed vs inst IR counts
+
+        h.old_temp   = 25 
+        h.last_rq_time = time.time()
+
+        heaters.append(h)
+        # connect each one to a logger
+        logfile = '{}/{}-{}.log'.format(args.logpath, name, _logtime)
+        logger = loglib.LogCASUActivity(h, logfile, append=False, delimiter=';')
+        loggers.append(logger)
+    #}}}
+    # run calibration
+    for h in heaters:
+        clib._calibrate(h, calib_steps=50, calib_gain=1.1, interval=0.1)
+        # and RECORD THE VALUES!
+        calib_file = '{}/{}-{}.calib'.format(args.logpath, name, _logtime)
+        with open(calib_file, 'w') as f:
+            _ts ="; ".join(["{:}".format(x) for x in h.threshold])
+            f.write(_ts + "\n")
+            print "[I] post-calibration, we have thresh: ", _ts
+
+    try:
+        #{{{ main runtime controller behaviour
+        ts = 0 # keep track of iterations round this loop
+        while True:
+            any_updates = False # used for emitting debug output
+            ts += 1
+            for h, logger in zip(heaters, loggers):
+                now = time.time()
+                elap = now - init_upd_time
+
+                #{{{ measure inst proximity, compute l/t average
+                sat_meas_count = clib.detect_bee_proximity_saturated(h)
+
+                # compute an average recent detection value. (note: bound by ts)
+                valid = min(ts, shared_conf.avg_hist_len)
+                vd = np.array(h.detect_data[0:valid])
+                rd = np.array(h.detect_data[0:valid]) # keep one unclipped
+                vd[vd > h.sat_lim] = h.sat_lim # clip for analysis
+                r_mean = vd.mean()
+                r_med = np.median(vd)
+                r_max = vd.max()
+                #}}}
+
+                #{{{ check for messages from neighbours
+                # recv neighbouring Bee estimate/IR count
+                # - use neighbouring value only if there is a neighbour
+                if h._listento is not None:
+                    msgs = clib.recv_all_msgs(h)
+                    if h.verb >1 : print "[I] {} received {} msgs:".format(h._thename, len(msgs))
+
+                    for src_phys, val in msgs:
+                        if src_phys in h.comm_links:
+                            apdx_str = "(unknown)"
+                            if h.comm_links[src_phys] == "accomplice":
+                                h.friend_rx += 1
+                                apdx_str = "F({})".format(h.friend_rx)
+                                h.friend_most_recent_val = val
+
+                            elif h.comm_links[src_phys] == "enemy":
+                                h.enemy_rx += 1
+                                h.enemy_most_recent_val = val
+                                apdx_str = "E({})".format(h.enemy_rx)
+
+                        if h.verb > 1: print ("  [I] recv message from '{}'"
+                                " => logical neighbor '{:12}'. Msg:{}|{}").format(
+                            src_phys, h.comm_links[src_phys], val, apdx_str)
+                #}}}
+
+                #{{{ compute new temperature
+                # NONLINEAR COMBINATION. Also with smoother data
+                excit_total = h.self_bias * r_mean
+                if shared_conf.remote_excit:
+                    excit_total = (h.self_bias * r_mean +
+                            h.friend_bias * h.friend_most_recent_val)
+
+                lc = excit_total / float(h.sat_lim) # normalised
+                local_contrib = shared_conf.temp_rng * lc
+
+                rbc2 = h.enemy_most_recent_val / float(h.sat_lim)
+                remote_contrib = h.sat_lim * rbc2 * h.enemy_bias
+
+                if shared_conf.cross_inhib:
+                    new_temp = shared_conf.min_temp + local_contrib - remote_contrib
+                else:
+                    new_temp = shared_conf.min_temp + local_contrib
+
+                # for display, generate a summary message
+                contrib_str = ("L|C|R IR[{:{fmtIR}}|{:{fmtIR}}|{:{fmtIR}}]"
+                               " T[{:{fmtT}}|{:{fmtT}}|{:{fmtT}}] ").format(
+                        r_mean, h.friend_most_recent_val, rbc2,
+                        h.self_bias * r_mean,
+                        h.friend_bias * h.friend_most_recent_val,
+                        -remote_contrib,
+                        fmtIR=".1f", fmtT="+.1f"
+                        )
+                # an appendix to message (re temp)
+                contrib_str += "{:.1f}+{:.1f} => {} {:.1f}{}".format(shared_conf.min_temp,
+                        new_temp-shared_conf.min_temp, clib.BLU, new_temp, clib.ENDC)
+
+                # protect / clip temperature value
+                new_temp = sorted([shared_conf.min_temp, new_temp, shared_conf.max_temp])[1]
+                #}}}
+
+                #{{{ do we need to update setpoint this iteration?
+                update_temp_now = False
+                if now - h.last_update_time > shared_conf.update_period:
+                    update_temp_now = True # this casu
+                    any_updates = True     # shared flag for all casus (disp)
+                #}}}
+
+                # set color, based on target and current temp (always update clr)
+                t_cur = clib.find_mean_ext_temp(h)
+                r,g,b = clib.gen_clr_tgt(
+                    h.prev_temp, cmap_fake, t_cur, min_temp=shared_conf.min_temp,
+                    max_temp=shared_conf.max_temp)
+                r = rd.mean() / 6.0
+                #new_temp = shared_conf.min_temp + local_contrib - remote_contrib
+                #
+
+                if ENABLE_SET_LEDS:
+                    # this is a small validation to check we have inter-comms ok
+
+                    pos = h.self_bias * r_mean + h.friend_bias * h.friend_most_recent_val
+                    neg = h.enemy_bias * rbc2
+                    _test_x = pos - neg
+
+                    if _test_x > 0: r,g,b = (1,0,1) # PURPLE
+                    if _test_x > 1: r,g,b = (0,0,1) # B;IE
+                    if _test_x > 2: r,g,b = (0,1,0) # GREEN
+                    if _test_x > 3: r,g,b = (1,1,0) # YELLOW
+                    if _test_x > 4: r,g,b = (1,0.6,0) # orange
+                    if _test_x > 5: r,g,b = (1,0,0) # red
+                    print "test_val: {:.2f}; rgb=".format(_test_x), r,g,b
+                    h.set_diagnostic_led_rgb(r=r,g=g,b=b)
+
+                if (update_temp_now):
+                #{{{ if so, change temperature and LED display clr
+                    if ENABLE_SET_TEMP:
+                        update_temp_wrapper(h, new_temp, ref_deviate=0.5)
+
+
+                    h.prev_temp = new_temp
+                    h.last_update_time = time.time()
+
+                    #{{{ diagnostic messages to cmdline
+                    # a bit of diagnostics on the colouring
+                    print "[ts={} ({:.0f}m{:.0f}s)] {}: {}T=>{:.2f} {}(T_cur={:.2f}), ".format(
+                        ts, (ts*shared_conf.resample_period)/60, (ts * shared_conf.resample_period) % 60, h._thename, clib.BLU, new_temp, clib.ENDC, t_cur,
+                    )
+
+                    # some info on the (mis)match between the instantaneous reading and the
+                    # time-averaged version. [CLIPPED DATA]
+                    print "\tinst: {}, mean|med|max recent: {:.2f}|{:.2f}|{:.2f}".format(
+                        sat_meas_count, r_mean, r_med, r_max), #vd,
+                    err = np.abs(sat_meas_count - r_mean)
+                    if err > 0.5:
+                        h.err_cnt += 1
+                        print clib.ERR + "[W] {:.2f} away ({}|{} errs)".format(err, h.err_cnt, ts/shared_conf.rel_upd_rate) + clib.ENDC,
+                    print " [LED{:.2f}]".format(r)
+
+                    # (mis)match between instantaneous and time-average [UNCLIPPED]
+                    print "\tinst: {}, mean|med|max recent: {:.2f}|{:.2f}|{:.2f}".format(
+                        int(rd[0]), rd.mean(), np.median(rd), rd.max()), #rd,
+                    err = np.abs(rd[0] - rd.mean())
+                    if err > 0.5:
+                        print clib.ERR + "[W] {:.2f} away ({}|{} errs)".format(err, "?", ts/shared_conf.rel_upd_rate) + clib.ENDC,
+                    # decomposition of contributions
+                    print "\n\t" + contrib_str
+                    #}}}
+                #}}}
+
+                # transmit my count -- if have neigbours, always send.
+                for neigh in h._sendto: #(send time-averaged, saturated value
+                    clib.transmit_my_count( h, "{:.3f}".format(r_mean), neigh);
+
+                #{{{ make a log entry
+                # - includes the counts made as well as basic sensor measrements
+                extra_recs = [sat_meas_count , h.friend_most_recent_val,
+                              h.enemy_most_recent_val, new_temp, rd[0], rd.mean()]
+                extra_string = ";".join([str(x) for x in extra_recs])
+                logger.record_sensors(suffix=extra_string)
+                #}}}
+
+            # sleep between updating all N casus
+            if any_updates: clib.sep_with_nowtime()
+            time.sleep(shared_conf.resample_period)
+        #}}}
+
+    except KeyboardInterrupt:
+        #{{{ cleanup
+        print "closing down CASUs..."
+        for h in heaters:
+            h.stop()
+        for l in loggers:
+            l._cleanup()
+
+        #}}}
+


### PR DESCRIPTION
Code and configuration to run a two-arena coordination experiment, with two groups of real bees.

Tested with real hardware and bees, using four CASUs from the 3x3 array, at Graz 2015 workshop.  Parameters suitable for 15 bees per arena.  Robustness to bee population size is unknown at present.

Deployment as used at the workshop here - including a manual/hard-coded step (see script `_deploy_two_real_xinhib.sh`) that is already obsolete (due to enhancements in assisi-python) but retained in case of unforeseen incompatibility. 
